### PR TITLE
Fix - remove mosquitto k8s service declaration

### DIFF
--- a/service.tf
+++ b/service.tf
@@ -1,25 +1,25 @@
-resource "kubernetes_service_v1" "mosquitto" {
-  metadata {
-    name = "mosquitto"
-    labels = {
-      app = "mosquitto"
-    }
-  }
+# resource "kubernetes_service_v1" "mosquitto" {
+#   metadata {
+#     name = "mosquitto"
+#     labels = {
+#       app = "mosquitto"
+#     }
+#   }
 
-  spec {
-    port {
-      port        = 1883
-      target_port = 1883
-      name        = "mqtt"
-    }
-    port {
-      port        = 9001
-      target_port = 9001
-      name        = "wss"
-    }
-    selector = {
-      app = "mosquitto"
-    }
-    type = "ClusterIP"
-  }
-}
+#   spec {
+#     port {
+#       port        = 1883
+#       target_port = 1883
+#       name        = "mqtt"
+#     }
+#     port {
+#       port        = 9001
+#       target_port = 9001
+#       name        = "wss"
+#     }
+#     selector = {
+#       app = "mosquitto"
+#     }
+#     type = "ClusterIP"
+#   }
+# }


### PR DESCRIPTION
Fix:

```
Error: services "mosquitto" already exists
with kubernetes_service_v1.mosquitto
on service.tf line 1, in resource "kubernetes_service_v1" "mosquitto":

resource "kubernetes_service_v1" "mosquitto" {
```